### PR TITLE
Fix Django not using the Celery broker properl

### DIFF
--- a/Docker/cathapi/entrypoint.sh
+++ b/Docker/cathapi/entrypoint.sh
@@ -12,7 +12,7 @@ if 'CATHAPI_DEBUG' in os.environ:
         import cathapi.settings.dev as config
 else:
     import cathapi.settings.prod as config
-for url in [config.CACHES["default"]["LOCATION"], config.BROKER_URL,
+for url in [config.CACHES["default"]["LOCATION"], config.CELERY_BROKER_URL,
             config.CELERY_RESULT_BACKEND]:
     try:
         rds = redis.from_url(url)

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -102,8 +102,12 @@ services:
         - CATHSMAPI_GITTAG=$CATHSMAPI_GITTAG
     depends_on:
       - cathapi-redis
+      - postgres
     environment:
       - CATHAPI_DEBUG=CONTAINER
+      - POSTGRES_DB=$POSTGRES_DB
+      - DJANGO_DB_USR=$DJANGO_DB_USR
+      - DJANGO_DB_CLR_PW=$DJANGO_DB_CLR_PW
       - I_AM_CELERY=1
     command: celery -A cathapi worker
 

--- a/cathapi/celery.py
+++ b/cathapi/celery.py
@@ -23,7 +23,7 @@ app = Celery('cathapi')
 
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
-app.config_from_object('django.conf:settings')
+app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 

--- a/cathapi/settings/base.py
+++ b/cathapi/settings/base.py
@@ -56,7 +56,7 @@ sentry_sdk.init(
 
 # CELERY
 
-BROKER_URL = 'redis://localhost:6379'
+CELERY_BROKER_URL = 'redis://localhost:6379'
 CELERY_RESULT_BACKEND = 'redis://localhost:6379'
 CELERY_ACCEPT_CONTENT = ['application/json']
 CELERY_TASK_SERIALIZER = 'json'

--- a/cathapi/settings/container.py
+++ b/cathapi/settings/container.py
@@ -5,34 +5,33 @@ from decouple import config
 from .base import *
 
 # Bend the broker to the redis container
-BROKER_URL = 'redis://cathapi-redis:6379'
+CELERY_BROKER_URL = 'redis://cathapi-redis:6379'
 CELERY_RESULT_BACKEND = 'redis://cathapi-redis:6379'
 
 # These settings make sure any tasks run in testing 
 # are run locally with the 'test' database
-CELERY_ALWAYS_EAGER = True
 TEST_RUNNER = 'djcelery.contrib.test_runner.CeleryTestSuiteRunner'
 
 IS_CELERY = config('I_AM_CELERY', default=False, cast=bool)
 
-if not IS_CELERY:
-  # These settings are only relevant for Django instances
-  DEBUG = False
+DEBUG = False
 
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': config('POSTGRES_DB', default='cathapi', cast=str),
+        'USER': config('DJANGO_DB_USR', default='cathapiuser', cast=str),
+        'PASSWORD': config('DJANGO_DB_CLR_PW', cast=str),
+        'HOST': config('PG_HOST', default='postgres', cast=str),
+        'PORT': config('PG_PORT', default=5432, cast=int),
+    }
+ }
+
+if not IS_CELERY:
   # Bend the Django cache to use the redis container
   CACHES["default"]["LOCATION"] = "redis://cathapi-redis:6379/1"
 
-  DATABASES = {
-      'default': {
-          'ENGINE': 'django.db.backends.postgresql_psycopg2',
-          'NAME': config('POSTGRES_DB', default='cathapi', cast=str),
-          'USER': config('DJANGO_DB_USR', default='cathapiuser', cast=str),
-          'PASSWORD': config('DJANGO_DB_CLR_PW', cast=str),
-          'HOST': config('PG_HOST', default='postgres', cast=str),
-          'PORT': config('PG_PORT', default=5432, cast=int),
-      }
-   }
-
+# These settings are only relevant for Django instances
   STATICFILES_DIRS = [
       os.path.join('static/'),
   ]


### PR DESCRIPTION
Removes `TASK_ALWAYS_EAGER` from settings (it is already properly handled by the test suite) and moved BROKER_URL to CELERY_BROKER_URL so Celery gets all the settings, now. Celery settings are now served from namespace `CELERY`.